### PR TITLE
Add attribute selectors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.{js,json}]
+indent_style = space
+indent_size = 2

--- a/lib/main.js
+++ b/lib/main.js
@@ -17,9 +17,13 @@ function HTMLUglify(config) {
   this.whitelist = config.whitelist || [];
 }
 
-HTMLUglify.prototype.checkForCompoundPointer = function(lookups, type, value) {
+HTMLUglify.prototype.checkForStandardPointer = function(lookups, type, value) {
+  return lookups[type] && lookups[type][value];
+};
+
+HTMLUglify.prototype.checkForAttributePointer = function(lookups, type, value) {
   var pointer;
-  var typeLookups = lookups[type] || {}
+  var typeLookups = lookups[type] || {};
   var keys = Object.keys(typeLookups);
 
   keys.forEach(function(key) {
@@ -31,26 +35,33 @@ HTMLUglify.prototype.checkForCompoundPointer = function(lookups, type, value) {
   return pointer;
 };
 
-HTMLUglify.prototype.determinePointer = function(type, value, lookups) {
-  // First check for existing pointer
-  var existingPointer = lookups[type] && lookups[type][value];
-  if (existingPointer) {
-    return existingPointer;
-  }
-
-  // Second check for compound pointer
-  var compoundPointer = this.checkForCompoundPointer(lookups, type, value);
-  if (compoundPointer) {
-    return compoundPointer;
-  }
-
-  // Otherwise, third generate a new pointer
+HTMLUglify.prototype.generatePointer = function(lookups) {
   var idCount = Object.keys(lookups['id'] || {}).length;
   var classCount = Object.keys(lookups['class'] || {}).length;
-
   var counter = idCount + classCount;
-  var pointer = this.hashids.encode(counter);
 
+  return this.hashids.encode(counter);
+};
+
+HTMLUglify.prototype.pointer = function(type, value, lookups) {
+  return this.checkForStandardPointer(lookups, type, value) ||
+    this.checkForAttributePointer(lookups, type, value) ||
+    this.generatePointer(lookups);
+};
+
+HTMLUglify.prototype.insertLookup = function(type, value, pointer, lookups) {
+  if (!lookups[type]) {
+    lookups[type] = {};
+  }
+  lookups[type][value] = pointer;
+};
+
+HTMLUglify.prototype.createLookup = function(type, value, lookups) {
+  var pointer;
+  if (value && !this.isWhitelisted(type, value)) {
+    pointer = this.pointer(type, value, lookups);
+    this.insertLookup(type, value, pointer, lookups);
+  }
   return pointer;
 };
 
@@ -73,15 +84,15 @@ HTMLUglify.prototype.pointerizeClass = function($element, lookups) {
   var self = this;
   var value = $element.attr('class');
 
-  if (value && !this.isWhitelisted('class', value)) {
+  if (value) {
     var splitClasses = value.split(/\s+/);
+
     splitClasses.forEach(function(value) {
-      var pointer = self.determinePointer('class', value, lookups);
-
-      $element.removeClass(value);
-      $element.addClass(pointer);
-
-      self.populateLookups('class', value, pointer, lookups);
+      var pointer = self.createLookup('class', value, lookups);
+      if (pointer) {
+        $element.removeClass(value);
+        $element.addClass(pointer);
+      }
     });
   }
 };
@@ -89,19 +100,79 @@ HTMLUglify.prototype.pointerizeClass = function($element, lookups) {
 HTMLUglify.prototype.pointerizeIdAndFor = function(type, $element, lookups) {
   var value = $element.attr(type);
 
-  if (value && !this.isWhitelisted('id', value)) {
-    var pointer = this.determinePointer('id', value, lookups);
-
+  var pointer = this.createLookup('id', value, lookups);
+  if (pointer) {
     $element.attr(type, pointer);
-    this.populateLookups('id', value, pointer, lookups);
   }
 };
 
-HTMLUglify.prototype.populateLookups = function(type, value, pointer, lookups) {
-  if (!lookups[type]) {
-    lookups[type] = {};
-  }
-  lookups[type][value] = pointer;
+HTMLUglify.prototype.processRules = function(rules, lookups) {
+  var self = this;
+
+  rules.forEach(function(rule) {
+    // go deeper inside media rule to find css rules
+    if (rule.type === 'atrule' && rule.name === 'media') {
+      self.processRules(rule.nodes, lookups);
+    } else if (rule.type === 'rule') {
+      var parts = rule.selector.split(/ |\:not\(|\)|\>|\~|\+|\:\:|\:checked|\:after|\:before|\:root|\:|\[|\]|(?=\s*\.)|(?=\s*\#)|\,/);
+      parts.forEach(function(part) {
+        var pointer;
+        var value;
+
+        // handle #something
+        if (part.indexOf('#') > -1) {
+          value = part.replace(/\#/g, '');
+          pointer = self.createLookup('id', value, lookups);
+        }
+
+        // handle .something
+        if (part.indexOf('.') > -1) {
+          value = part.replace(/\./g, '');
+          pointer = self.createLookup('class', value, lookups);
+        }
+
+        // handle *[id=something] or *[id*=something]
+        if (
+          part.indexOf('id=') > -1 || 
+          part.indexOf('id*=') > -1 ||
+          part.indexOf('id^=') > -1 ||
+          part.indexOf('id$=') > -1
+        ) {
+          value = part.replace(/id\*?\^?\$?=|\"|\'/g, '');
+          pointer = self.createLookup('id', value, lookups);
+        }
+
+        // handle *[class=something] or *[class*=something]
+        if (
+          part.indexOf('class=') > -1 || 
+          part.indexOf('class*=') > -1 ||
+          part.indexOf('class^=') > -1 ||
+          part.indexOf('class$=') > -1
+        ) {
+          value = part.replace(/class\*?\^?\$?=|\"|\'/g, '');
+          pointer = self.createLookup('class', value, lookups);
+        }
+
+        // handle *[for=something] or *[for*=something]
+        if (
+          part.indexOf('for=') > -1 || 
+          part.indexOf('for*=') > -1 ||
+          part.indexOf('for^=') > -1 ||
+          part.indexOf('for$=') > -1
+        ) {
+          value = part.replace(/for\*?\^?\$?=|\"|\'/g, '');
+          pointer = self.createLookup('id', value, lookups);
+        }
+
+        if (pointer) {
+          var regex = new RegExp('(?!^)' + value); // negative look ahead to avoid start of the string
+          var newSelectorPart = part.replace(regex, pointer);
+          var newSelector = rule.selector.replace(part, newSelectorPart);
+          rule.selector = newSelector;
+        }
+      });
+    }
+  });
 };
 
 HTMLUglify.prototype.rewriteElements = function($, lookups) {
@@ -124,101 +195,6 @@ HTMLUglify.prototype.rewriteElements = function($, lookups) {
   return $;
 };
 
-HTMLUglify.prototype.setNewSelector = function(lead, rule, toReplace, pointer) {
-  toReplace = [lead, toReplace].join('');
-  pointer = [lead, pointer].join('');
-  var newSelector = rule.selector.replace(toReplace, pointer);
-  rule.selector = newSelector;
-};
-
-HTMLUglify.prototype.processRules = function(rules, lookups) {
-  var self = this;
-
-  rules.forEach(function(rule) {
-    // go deeper inside media rule to find css rules
-    if (rule.type === 'atrule' && rule.name === 'media') {
-      self.processRules(rule.nodes, lookups);
-    } else if (rule.type === 'rule') {
-      var selectorParts = rule.selector.split(/ |\:not\(|\)|\>|\~|\+|\:\:|\:checked|\:after|\:before|\:root|\:|\[|\]|(?=\s*\.)|(?=\s*\#)|\,/);
-      selectorParts.forEach(function(selectorPart) {
-        var pointer;
-        var value;
-
-        // handle #something
-        if (selectorPart.indexOf('#') > -1) {
-          value = selectorPart.replace(/\#/g, '');
-
-          if (value && !self.isWhitelisted('id', value)) {
-            pointer = self.determinePointer('id', value, lookups);
-            self.populateLookups('id', value, pointer, lookups);
-          }
-        }
-
-        // handle .something
-        if (selectorPart.indexOf('.') > -1) {
-          value = selectorPart.replace(/\./g, '');
-
-          if (value && !self.isWhitelisted('class', value)) {
-            pointer = self.determinePointer('class', value, lookups);
-            self.populateLookups('class', value, pointer, lookups);
-          }
-        }
-
-        // handle *[id=something] or *[id*=something]
-        if (
-          selectorPart.indexOf('id=') > -1 || 
-          selectorPart.indexOf('id*=') > -1 ||
-          selectorPart.indexOf('id^=') > -1 ||
-          selectorPart.indexOf('id$=') > -1
-        ) {
-          value = selectorPart.replace(/id\*?\^?\$?=|\"|\'/g, '');
-          if (value && !self.isWhitelisted('id', value)) {
-            pointer = self.determinePointer('id', value, lookups);
-            self.populateLookups('id', value, pointer, lookups);
-          }
-        }
-
-        // handle *[class=something] or *[class*=something]
-        if (
-          selectorPart.indexOf('class=') > -1 || 
-          selectorPart.indexOf('class*=') > -1 ||
-          selectorPart.indexOf('class^=') > -1 ||
-          selectorPart.indexOf('class$=') > -1
-        ) {
-          value = selectorPart.replace(/class\*?\^?\$?=|\"|\'/g, '');
-
-          if (value && !self.isWhitelisted('class', value)) {
-            pointer = self.determinePointer('class', value, lookups);
-            self.populateLookups('class', value, pointer, lookups);
-          }
-        }
-
-        // handle *[for=something] or *[for*=something]
-        if (
-          selectorPart.indexOf('for=') > -1 || 
-          selectorPart.indexOf('for*=') > -1 ||
-          selectorPart.indexOf('for^=') > -1 ||
-          selectorPart.indexOf('for$=') > -1
-        ) {
-          value = selectorPart.replace(/for\*?\^?\$?=|\"|\'/g, '');
-
-          if (value && !self.isWhitelisted('id', value)) {
-            pointer = self.determinePointer('id', value, lookups);
-            self.populateLookups('id', value, pointer, lookups);
-          }
-        }
-
-        if (pointer) {
-          var regex = new RegExp('(?!^)' + value); // negative look ahead to avoid start of the string
-          var newSelectorPart = selectorPart.replace(regex, pointer);
-          var newSelector = rule.selector.replace(selectorPart, newSelectorPart);
-          rule.selector = newSelector;
-        }
-      });
-    }
-  });
-};
-
 HTMLUglify.prototype.rewriteStyles = function($, lookups) {
   var self = this;
 
@@ -233,7 +209,6 @@ HTMLUglify.prototype.rewriteStyles = function($, lookups) {
 
   return $;
 };
-
 
 HTMLUglify.prototype.process = function(html) {
   var lookups = {};

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('string.prototype.startswith');
+
 var cheerio = require('cheerio');
 var Hashids = require('hashids');
 var postcssSafeParser = require('postcss-safe-parser');
@@ -18,16 +20,39 @@ function HTMLUglify(config) {
   this.whitelist = config.whitelist || [];
 }
 
+HTMLUglify.prototype.checkForCompoundPointer = function(lookups, lookupKey) {
+  var pointer;
+  var keys = Object.keys(lookups);
+
+  keys.forEach(function(key) {
+    if (lookupKey.startsWith(key)) {
+      var remainder = lookupKey.replace(key, '');
+      pointer = lookups[key] + remainder;
+    }
+  });
+
+  return pointer;
+};
+
 HTMLUglify.prototype.determinePointer = function(type, value, lookups) {
   var lookupKey = [type, value].join(LOOKUP_DELIMITER);
-  var existingPointer = lookups[lookupKey];
 
+  // First check for existing pointer
+  var existingPointer = lookups[lookupKey];
   if (existingPointer) {
     return existingPointer;
   }
 
+  // Second check for compound pointer
+  var compoundPointer = this.checkForCompoundPointer(lookups, lookupKey);
+  if (compoundPointer) {
+    return compoundPointer;
+  }
+
+  // Otherwise, third generate a new pointer
   var counter = Object.keys(lookups).length;
   var pointer = this.hashids.encode(counter);
+
   return pointer;
 };
 
@@ -47,18 +72,18 @@ HTMLUglify.prototype.isWhitelisted = function(type, value) {
 };
 
 HTMLUglify.prototype.pointerizeClass = function($element, lookups) {
-  var _this = this;
+  var self = this;
   var value = $element.attr('class');
 
   if (value && !this.isWhitelisted('class', value)) {
     var splitClasses = value.split(/\s+/);
     splitClasses.forEach(function(value) {
-      var pointer = _this.determinePointer('class', value, lookups);
+      var pointer = self.determinePointer('class', value, lookups);
 
       $element.removeClass(value);
       $element.addClass(pointer);
 
-      _this.populateLookups('class', value, pointer, lookups);
+      self.populateLookups('class', value, pointer, lookups);
     });
   }
 };
@@ -70,7 +95,7 @@ HTMLUglify.prototype.pointerizeIdAndFor = function(type, $element, lookups) {
     var pointer = this.determinePointer('id', value, lookups);
 
     $element.attr(type, pointer);
-    this.populateLookups('id', value, pointer, lookups); // always set to id for lookups
+    this.populateLookups('id', value, pointer, lookups);
   }
 };
 
@@ -80,20 +105,20 @@ HTMLUglify.prototype.populateLookups = function(type, value, pointer, lookups) {
 };
 
 HTMLUglify.prototype.rewriteElements = function($, lookups) {
-  var _this = this;
+  var self = this;
 
   lookups = lookups || {};
 
   $('*[id]').each(function() {
-    _this.pointerizeIdAndFor('id', $(this), lookups);
+    self.pointerizeIdAndFor('id', $(this), lookups);
   });
 
   $('*[for]').each(function() {
-    _this.pointerizeIdAndFor('for', $(this), lookups);
+    self.pointerizeIdAndFor('for', $(this), lookups);
   });
 
   $('*[class]').each(function() {
-    _this.pointerizeClass($(this), lookups);
+    self.pointerizeClass($(this), lookups);
   });
 
   return $;
@@ -107,52 +132,69 @@ HTMLUglify.prototype.setNewSelector = function(lead, rule, toReplace, pointer) {
 };
 
 HTMLUglify.prototype.processRules = function(rules, lookups) {
-  var _this = this;
+  var self = this;
 
   rules.forEach(function(rule) {
     // go deeper inside media rule to find css rules
     if (rule.type === 'atrule' && rule.name === 'media') {
-      _this.processRules(rule.nodes, lookups);
+      self.processRules(rule.nodes, lookups);
     } else if (rule.type === 'rule') {
       var selectorParts = rule.selector.split(/ |\:not\(|\)|\>|\~|\+|\:\:|\:checked|\:after|\:before|\:root|\:|\[|\]|(?=\s*\.)|(?=\s*\#)|\,/);
       selectorParts.forEach(function(selectorPart) {
-        var keyLookup = '';
-        var toReplace;
+        var pointer;
+        var value;
 
         // handle #something
         if (selectorPart.indexOf('#') > -1) {
-          toReplace = selectorPart.replace(/\#/g, '');
-          keyLookup = ['id', toReplace].join(LOOKUP_DELIMITER);
+          value = selectorPart.replace(/\#/g, '');
+
+          if (value && !self.isWhitelisted('id', value)) {
+            pointer = self.determinePointer('id', value, lookups);
+            self.populateLookups('id', value, pointer, lookups);
+          }
         }
 
         // handle .something
         if (selectorPart.indexOf('.') > -1) {
-          toReplace = selectorPart.replace(/\./g, '');
-          keyLookup = ['class', toReplace].join(LOOKUP_DELIMITER);
+          value = selectorPart.replace(/\./g, '');
+
+          if (value && !self.isWhitelisted('class', value)) {
+            pointer = self.determinePointer('class', value, lookups);
+            self.populateLookups('class', value, pointer, lookups);
+          }
         }
 
-        // handle *[id=something]
-        if (selectorPart.indexOf('id=') > -1){
-          toReplace = selectorPart.replace(/id=/g, '').replace(/\"/g, ''); // remove quotes from "somevalue"
-          keyLookup = ['id', toReplace].join(LOOKUP_DELIMITER);
+        // handle *[id=something] or *[id*=something]
+        if (selectorPart.indexOf('id=') > -1 || selectorPart.indexOf('id*=') > -1){
+          value = selectorPart.replace(/id\*?=|\"|\'/g, '');
+          if (value && !self.isWhitelisted('id', value)) {
+            pointer = self.determinePointer('id', value, lookups);
+            self.populateLookups('id', value, pointer, lookups);
+          }
         }
 
-        // handle *[class=something]
-        if (selectorPart.indexOf('class=') > -1) {
-          toReplace = selectorPart.replace(/class=/g, '');
-          keyLookup = ['class', toReplace].join(LOOKUP_DELIMITER);
+        // handle *[class=something] or *[class*=something]
+        if (selectorPart.indexOf('class=') > -1 || selectorPart.indexOf('class*=') > -1) {
+          value = selectorPart.replace(/class\*?=|\"|\'/g, '');
+
+          if (value && !self.isWhitelisted('class', value)) {
+            pointer = self.determinePointer('class', value, lookups);
+            self.populateLookups('class', value, pointer, lookups);
+          }
         }
 
-        // handle *[for=something]
-        if (selectorPart.indexOf('for=') > -1){
-          toReplace = selectorPart.replace(/for=/g, '');
-          toReplace = toReplace.replace(/\"/g, ''); // remove quotes from "somevalue"
-          keyLookup = ['id', toReplace].join(LOOKUP_DELIMITER);
+        // handle *[for=something] or *[for*=something]
+        if (selectorPart.indexOf('for=') > -1 || selectorPart.indexOf('for*=') > -1){
+          value = selectorPart.replace(/for\*?=|\"|\'/g, '');
+
+          if (value && !self.isWhitelisted('id', value)) {
+            pointer = self.determinePointer('id', value, lookups);
+            self.populateLookups('id', value, pointer, lookups);
+          }
         }
 
-        var pointer = lookups[keyLookup];
         if (pointer) {
-          var regex = new RegExp('(?!^)' + toReplace); // negative look ahead to avoid start of the string
+          var regex = new RegExp('(?!^)' + value); // negative look ahead to avoid start of the string
           var newSelectorPart = selectorPart.replace(regex, pointer);
           var newSelector = rule.selector.replace(selectorPart, newSelectorPart);
           rule.selector = newSelector;
@@ -163,26 +205,27 @@ HTMLUglify.prototype.processRules = function(rules, lookups) {
 };
 
 HTMLUglify.prototype.rewriteStyles = function($, lookups) {
-  var _this = this;
+  var self = this;
 
   lookups = lookups || {};
 
   $('style').each(function() {
     var $style = $(this);
     var ast = postcssSafeParser($style.text());
-    _this.processRules(ast.nodes, lookups);
+    self.processRules(ast.nodes, lookups);
     $style.text(ast.toString());
   });
 
   return $;
 };
 
+
 HTMLUglify.prototype.process = function(html) {
   var lookups = {};
 
   var $ = cheerio.load(html);
-  $ = this.rewriteElements($, lookups);
   $ = this.rewriteStyles($, lookups);
+  $ = this.rewriteElements($, lookups);
 
   return $.html();
 };

--- a/lib/main.js
+++ b/lib/main.js
@@ -18,16 +18,15 @@ function HTMLUglify(config) {
   this.whitelist = config.whitelist || [];
 }
 
-HTMLUglify.prototype.checkForCompoundPointer = function(lookups, lookupKey) {
+HTMLUglify.prototype.checkForCompoundPointer = function(lookups, value) {
   var pointer;
   var keys = Object.keys(lookups);
 
   keys.forEach(function(key) {
     var keyValue = key.split('=')[1]
-    var lookupKeyValue = lookupKey.split('=')[1]
 
-    if (lookupKeyValue.indexOf(keyValue) !== -1) {
-      pointer = lookupKeyValue.replace(keyValue, lookups[key]);
+    if (value.indexOf(keyValue) !== -1) {
+      pointer = value.replace(keyValue, lookups[key]);
     }
   });
 
@@ -44,7 +43,7 @@ HTMLUglify.prototype.determinePointer = function(type, value, lookups) {
   }
 
   // Second check for compound pointer
-  var compoundPointer = this.checkForCompoundPointer(lookups, lookupKey);
+  var compoundPointer = this.checkForCompoundPointer(lookups, value);
   if (compoundPointer) {
     return compoundPointer;
   }

--- a/lib/main.js
+++ b/lib/main.js
@@ -138,7 +138,7 @@ HTMLUglify.prototype.processRules = function(rules, lookups) {
           part.indexOf('id^=') > -1 ||
           part.indexOf('id$=') > -1
         ) {
-          value = part.replace(/id\*?\^?\$?=|\"|\'/g, '');
+          value = part.replace(/id[\*\^\$]?=|\"|\'/g, '');
           pointer = self.createLookup('id', value, lookups);
         }
 
@@ -149,7 +149,7 @@ HTMLUglify.prototype.processRules = function(rules, lookups) {
           part.indexOf('class^=') > -1 ||
           part.indexOf('class$=') > -1
         ) {
-          value = part.replace(/class\*?\^?\$?=|\"|\'/g, '');
+          value = part.replace(/class[\*\^\$]?=|\"|\'/g, '');
           pointer = self.createLookup('class', value, lookups);
         }
 
@@ -160,7 +160,7 @@ HTMLUglify.prototype.processRules = function(rules, lookups) {
           part.indexOf('for^=') > -1 ||
           part.indexOf('for$=') > -1
         ) {
-          value = part.replace(/for\*?\^?\$?=|\"|\'/g, '');
+          value = part.replace(/for[\*\^\$]?=|\"|\'/g, '');
           pointer = self.createLookup('id', value, lookups);
         }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -6,7 +6,6 @@ var postcssSafeParser = require('postcss-safe-parser');
 
 var ALPHABET = 'abcdefghijklmnopqrstuvwxyz';
 var VERSION = require('../package.json').version;
-var LOOKUP_DELIMITER = '=';
 
 function HTMLUglify(config) {
   this.version = VERSION;
@@ -18,15 +17,14 @@ function HTMLUglify(config) {
   this.whitelist = config.whitelist || [];
 }
 
-HTMLUglify.prototype.checkForCompoundPointer = function(lookups, value) {
+HTMLUglify.prototype.checkForCompoundPointer = function(lookups, type, value) {
   var pointer;
-  var keys = Object.keys(lookups);
+  var typeLookups = lookups[type] || {}
+  var keys = Object.keys(typeLookups);
 
   keys.forEach(function(key) {
-    var keyValue = key.split('=')[1];
-
-    if (value.indexOf(keyValue) !== -1) {
-      pointer = value.replace(keyValue, lookups[key]);
+    if (value.indexOf(key) !== -1) {
+      pointer = value.replace(key, typeLookups[key]);
     }
   });
 
@@ -34,22 +32,23 @@ HTMLUglify.prototype.checkForCompoundPointer = function(lookups, value) {
 };
 
 HTMLUglify.prototype.determinePointer = function(type, value, lookups) {
-  var lookupKey = [type, value].join(LOOKUP_DELIMITER);
-
   // First check for existing pointer
-  var existingPointer = lookups[lookupKey];
+  var existingPointer = lookups[type] && lookups[type][value];
   if (existingPointer) {
     return existingPointer;
   }
 
   // Second check for compound pointer
-  var compoundPointer = this.checkForCompoundPointer(lookups, value);
+  var compoundPointer = this.checkForCompoundPointer(lookups, type, value);
   if (compoundPointer) {
     return compoundPointer;
   }
 
   // Otherwise, third generate a new pointer
-  var counter = Object.keys(lookups).length;
+  var idCount = Object.keys(lookups['id'] || {}).length;
+  var classCount = Object.keys(lookups['class'] || {}).length;
+
+  var counter = idCount + classCount;
   var pointer = this.hashids.encode(counter);
 
   return pointer;
@@ -99,8 +98,10 @@ HTMLUglify.prototype.pointerizeIdAndFor = function(type, $element, lookups) {
 };
 
 HTMLUglify.prototype.populateLookups = function(type, value, pointer, lookups) {
-  var key = [type, value].join(LOOKUP_DELIMITER);
-  lookups[key] = pointer;
+  if (!lookups[type]) {
+    lookups[type] = {};
+  }
+  lookups[type][value] = pointer;
 };
 
 HTMLUglify.prototype.rewriteElements = function($, lookups) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('string.prototype.startswith');
-
 var cheerio = require('cheerio');
 var Hashids = require('hashids');
 var postcssSafeParser = require('postcss-safe-parser');
@@ -25,9 +23,11 @@ HTMLUglify.prototype.checkForCompoundPointer = function(lookups, lookupKey) {
   var keys = Object.keys(lookups);
 
   keys.forEach(function(key) {
-    if (lookupKey.startsWith(key)) {
-      var remainder = lookupKey.replace(key, '');
-      pointer = lookups[key] + remainder;
+    var keyValue = key.split('=')[1]
+    var lookupKeyValue = lookupKey.split('=')[1]
+
+    if (lookupKeyValue.indexOf(keyValue) !== -1) {
+      pointer = lookupKeyValue.replace(keyValue, lookups[key]);
     }
   });
 
@@ -165,8 +165,13 @@ HTMLUglify.prototype.processRules = function(rules, lookups) {
         }
 
         // handle *[id=something] or *[id*=something]
-        if (selectorPart.indexOf('id=') > -1 || selectorPart.indexOf('id*=') > -1){
-          value = selectorPart.replace(/id\*?=|\"|\'/g, '');
+        if (
+          selectorPart.indexOf('id=') > -1 || 
+          selectorPart.indexOf('id*=') > -1 ||
+          selectorPart.indexOf('id^=') > -1 ||
+          selectorPart.indexOf('id$=') > -1
+        ) {
+          value = selectorPart.replace(/id\*?\^?\$?=|\"|\'/g, '');
           if (value && !self.isWhitelisted('id', value)) {
             pointer = self.determinePointer('id', value, lookups);
             self.populateLookups('id', value, pointer, lookups);
@@ -174,8 +179,13 @@ HTMLUglify.prototype.processRules = function(rules, lookups) {
         }
 
         // handle *[class=something] or *[class*=something]
-        if (selectorPart.indexOf('class=') > -1 || selectorPart.indexOf('class*=') > -1) {
-          value = selectorPart.replace(/class\*?=|\"|\'/g, '');
+        if (
+          selectorPart.indexOf('class=') > -1 || 
+          selectorPart.indexOf('class*=') > -1 ||
+          selectorPart.indexOf('class^=') > -1 ||
+          selectorPart.indexOf('class$=') > -1
+        ) {
+          value = selectorPart.replace(/class\*?\^?\$?=|\"|\'/g, '');
 
           if (value && !self.isWhitelisted('class', value)) {
             pointer = self.determinePointer('class', value, lookups);
@@ -184,8 +194,13 @@ HTMLUglify.prototype.processRules = function(rules, lookups) {
         }
 
         // handle *[for=something] or *[for*=something]
-        if (selectorPart.indexOf('for=') > -1 || selectorPart.indexOf('for*=') > -1){
-          value = selectorPart.replace(/for\*?=|\"|\'/g, '');
+        if (
+          selectorPart.indexOf('for=') > -1 || 
+          selectorPart.indexOf('for*=') > -1 ||
+          selectorPart.indexOf('for^=') > -1 ||
+          selectorPart.indexOf('for$=') > -1
+        ) {
+          value = selectorPart.replace(/for\*?\^?\$?=|\"|\'/g, '');
 
           if (value && !self.isWhitelisted('id', value)) {
             pointer = self.determinePointer('id', value, lookups);

--- a/lib/main.js
+++ b/lib/main.js
@@ -23,7 +23,7 @@ HTMLUglify.prototype.checkForCompoundPointer = function(lookups, value) {
   var keys = Object.keys(lookups);
 
   keys.forEach(function(key) {
-    var keyValue = key.split('=')[1]
+    var keyValue = key.split('=')[1];
 
     if (value.indexOf(keyValue) !== -1) {
       pointer = value.replace(keyValue, lookups[key]);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "cheerio": "^0.19.0",
     "hashids": "^1.0.2",
-    "postcss-safe-parser": "^1.0.1"
+    "postcss-safe-parser": "^1.0.1",
+    "string.prototype.startswith": "^0.2.0"
   },
   "devDependencies": {
     "benchmark": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
   "dependencies": {
     "cheerio": "^0.19.0",
     "hashids": "^1.0.2",
-    "postcss-safe-parser": "^1.0.1",
-    "string.prototype.startswith": "^0.2.0"
+    "postcss-safe-parser": "^1.0.1"
   },
   "devDependencies": {
     "benchmark": "^1.0.0",

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -4,7 +4,7 @@ var fs = require('fs');
 var Benchmark = require('benchmark');
 var HTMLUglify = require('../lib/main.js');
 
-var suite = new Benchmark.Suite;
+var suite = new Benchmark.Suite();
 var htmlUglify = new HTMLUglify();
 
 console.log('Running benchmark');

--- a/test/main.js
+++ b/test/main.js
@@ -285,6 +285,78 @@ describe('HTMLUglify', function() {
     it('uglifies for attribute selectors', function() {
       var html = htmlUglify.process('<style>body[yahoo] *[id*=paddingreset] { padding:0 !important; }</style><div for="paddingreset1">paddingreset1</div>');
       assert.equal(html, '<style>body[yahoo] *[id*=xz] { padding:0 !important; }</style><div for="xz1">paddingreset1</div>');
+  });
+
+  describe('attribute selectors', function() {
+    describe('equal selector', function() {
+      it('uglifies', function() {
+        var html = htmlUglify.process('<style>*[class=test] {}</style><div class="test"></div>');
+        assert.equal(html, '<style>*[class=xz] {}</style><div class="xz"></div>');
+
+        var html = htmlUglify.process('<style>*[id=test] {}</style><div id="test"></div>');
+        assert.equal(html, '<style>*[id=xz] {}</style><div id="xz"></div>');
+
+        var html = htmlUglify.process('<style>*[id=test] {}</style><div for="test"></div>');
+        assert.equal(html, '<style>*[id=xz] {}</style><div for="xz"></div>');
+      });
+    });
+    describe('anywhere selector', function() {
+      it('uglifies in the middle of a string', function() {
+        var html = htmlUglify.process('<style>*[class*=test] {}</style><div class="ZZtestZZ"></div>');
+        assert.equal(html, '<style>*[class*=xz] {}</style><div class="ZZxzZZ"></div>');
+
+        var html = htmlUglify.process('<style>*[id*=test] {}</style><div id="ZZtestZZ"></div>');
+        assert.equal(html, '<style>*[id*=xz] {}</style><div id="ZZxzZZ"></div>');
+
+        var html = htmlUglify.process('<style>*[id*=test] {}</style><div for="ZZtestZZ"></div>');
+        assert.equal(html, '<style>*[id*=xz] {}</style><div for="ZZxzZZ"></div>');
+      });
+
+      it('uglifies at the start of a string', function() {
+        var html = htmlUglify.process('<style>*[class*=test] {}</style><div class="testZZ"></div>');
+        assert.equal(html, '<style>*[class*=xz] {}</style><div class="xzZZ"></div>');
+
+        var html = htmlUglify.process('<style>*[id*=test] {}</style><div id="testZZ"></div>');
+        assert.equal(html, '<style>*[id*=xz] {}</style><div id="xzZZ"></div>');
+
+        var html = htmlUglify.process('<style>*[id*=test] {}</style><div for="testZZ"></div>');
+        assert.equal(html, '<style>*[id*=xz] {}</style><div for="xzZZ"></div>');
+      });
+
+      it('uglifies at the end of a string', function() {
+        var html = htmlUglify.process('<style>*[class*=test] {}</style><div class="ZZtest"></div>');
+        assert.equal(html, '<style>*[class*=xz] {}</style><div class="ZZxz"></div>');
+
+        var html = htmlUglify.process('<style>*[id*=test] {}</style><div id="ZZtest"></div>');
+        assert.equal(html, '<style>*[id*=xz] {}</style><div id="ZZxz"></div>');
+
+        var html = htmlUglify.process('<style>*[id*=test] {}</style><div for="ZZtest"></div>');
+        assert.equal(html, '<style>*[id*=xz] {}</style><div for="ZZxz"></div>');
+      });
+    });
+    describe('begins with selector', function() {
+      it('uglifies at the start of a string', function() {
+        var html = htmlUglify.process('<style>*[class^=test] {}</style><div class="testZZ"></div>');
+        assert.equal(html, '<style>*[class^=xz] {}</style><div class="xzZZ"></div>');
+
+        var html = htmlUglify.process('<style>*[id^=test] {}</style><div id="testZZ"></div>');
+        assert.equal(html, '<style>*[id^=xz] {}</style><div id="xzZZ"></div>');
+
+        var html = htmlUglify.process('<style>*[id^=test] {}</style><div for="testZZ"></div>');
+        assert.equal(html, '<style>*[id^=xz] {}</style><div for="xzZZ"></div>');
+      });
+    });
+    describe('ends with selector', function() {
+      it('uglifies at the end of a string', function() {
+        var html = htmlUglify.process('<style>*[class$=test] {}</style><div class="ZZtest"></div>');
+        assert.equal(html, '<style>*[class$=xz] {}</style><div class="ZZxz"></div>');
+
+        var html = htmlUglify.process('<style>*[id$=test] {}</style><div id="ZZtest"></div>');
+        assert.equal(html, '<style>*[id$=xz] {}</style><div id="ZZxz"></div>');
+
+        var html = htmlUglify.process('<style>*[id$=test] {}</style><div for="ZZtest"></div>');
+        assert.equal(html, '<style>*[id$=xz] {}</style><div for="ZZxz"></div>');
+      });
     });
   });
 });

--- a/test/main.js
+++ b/test/main.js
@@ -50,7 +50,7 @@ describe('HTMLUglify', function() {
       var lookups = {
         'class=something': 'zzz'
       };
-      var lookupKey = 'class=somethingElse';
+      var lookupKey = 'somethingElse';
       var pointer = htmlUglify.checkForCompoundPointer(lookups, lookupKey);
 
       assert.equal(pointer, 'zzzElse');
@@ -285,6 +285,7 @@ describe('HTMLUglify', function() {
     it('uglifies for attribute selectors', function() {
       var html = htmlUglify.process('<style>body[yahoo] *[id*=paddingreset] { padding:0 !important; }</style><div for="paddingreset1">paddingreset1</div>');
       assert.equal(html, '<style>body[yahoo] *[id*=xz] { padding:0 !important; }</style><div for="xz1">paddingreset1</div>');
+    });
   });
 
   describe('attribute selectors', function() {
@@ -360,3 +361,4 @@ describe('HTMLUglify', function() {
     });
   });
 });
+

--- a/test/main.js
+++ b/test/main.js
@@ -39,7 +39,7 @@ describe('HTMLUglify', function() {
   describe('#checkForCompoundPointer', function() {
     it('returns undefined when name does not contain the same class', function() {
       var lookups = {
-        'class=something': 'zzz'
+        'class': { 'something': 'zzz' }
       };
       var value = 'other';
       var pointer = htmlUglify.checkForCompoundPointer(lookups, value);
@@ -48,10 +48,10 @@ describe('HTMLUglify', function() {
     });
     it('returns the pointer that starts with the same class', function() {
       var lookups = {
-        'class=something': 'zzz'
+        'class': { 'something': 'zzz' }
       };
       var value = 'somethingElse';
-      var pointer = htmlUglify.checkForCompoundPointer(lookups, value);
+      var pointer = htmlUglify.checkForCompoundPointer(lookups, 'class', value);
 
       assert.equal(pointer, 'zzzElse');
     });
@@ -72,14 +72,14 @@ describe('HTMLUglify', function() {
       assert.equal(results, '<style>#xz{ color: red; }</style>');
     });
     it('rewrites an id with the same name as the element', function() {
-      var lookups = { 'id=label': 'ab' };
+      var lookups = {'id': {'label': 'ab' }};
       var html = '<style>label#label{ color: blue; }</style>';
       var $ = cheerio.load(html);
       var results = htmlUglify.rewriteStyles($, lookups).html();
       assert.equal(results, '<style>label#ab{ color: blue; }</style>');
     });
     it('rewrites a for= given lookups', function() {
-      var lookups = { 'id=email': 'ab' };
+      var lookups = { 'id': {'email': 'ab'} };
       var html = '<style>label[for=email]{ color: blue; }</style>';
       var $ = cheerio.load(html);
       var results = htmlUglify.rewriteStyles($, lookups).html();
@@ -93,70 +93,70 @@ describe('HTMLUglify', function() {
       assert.equal(results, "<style>label[for=xz]{ color: blue; }</style>");
     });
     it('rewrites a for= with quotes given lookups', function() {
-      var lookups = { 'id=email': 'ab' };
+      var lookups = { 'id': {'email': 'ab'} };
       var html = '<style>label[for="email"]{ color: blue; }</style>';
       var $ = cheerio.load(html);
       var results = htmlUglify.rewriteStyles($, lookups).html();
       assert.equal(results, '<style>label[for="ab"]{ color: blue; }</style>');
     });
     it('rewrites a for= with the same name as the element', function() {
-      var lookups = { 'id=label': 'ab' };
+      var lookups = { 'id': { 'label': 'ab' }};
       var html = '<style>label[for="label"]{ color: blue; }</style>';
       var $ = cheerio.load(html);
       var results = htmlUglify.rewriteStyles($, lookups).html();
       assert.equal(results, '<style>label[for="ab"]{ color: blue; }</style>');
     });
     it('rewrites an id= given lookups', function() {
-      var lookups = { 'id=email': 'ab' };
+      var lookups = { 'id': {'email': 'ab'} };
       var html = '<style>label[id=email]{ color: blue; }</style>';
       var $ = cheerio.load(html);
       var results = htmlUglify.rewriteStyles($, lookups).html();
       assert.equal(results, '<style>label[id=ab]{ color: blue; }</style>');
     });
     it('rewrites an id= with quotes given lookups', function() {
-      var lookups = { 'id=email': 'ab' };
+      var lookups = { 'id': { 'email': 'ab' } };
       var html = '<style>label[id="email"]{ color: blue; }</style>';
       var $ = cheerio.load(html);
       var results = htmlUglify.rewriteStyles($, lookups).html();
       assert.equal(results, '<style>label[id="ab"]{ color: blue; }</style>');
     });
     it('rewrites an id= with quotes and with the same name as the element', function() {
-      var lookups = { 'id=label': 'ab' };
+      var lookups = { 'id': {'label': 'ab'} };
       var html = '<style>label[id="label"]{ color: blue; }</style>';
       var $ = cheerio.load(html);
       var results = htmlUglify.rewriteStyles($, lookups).html();
       assert.equal(results, '<style>label[id="ab"]{ color: blue; }</style>');
     });
     it('rewrites a class given lookups', function() {
-      var lookups = { 'class=email': 'ab' };
+      var lookups = { 'class': { 'email': 'ab' }};
       var html = '<style>label.email{ color: blue; }</style>';
       var $ = cheerio.load(html);
       var results = htmlUglify.rewriteStyles($, lookups).html();
       assert.equal(results, '<style>label.ab{ color: blue; }</style>');
     });
     it('rewrites a class with the same name as the element', function() {
-      var lookups = { 'class=label': 'ab' };
+      var lookups = { 'class': { 'label': 'ab' }};
       var html = '<style>label.label{ color: blue; }</style>';
       var $ = cheerio.load(html);
       var results = htmlUglify.rewriteStyles($, lookups).html();
       assert.equal(results, '<style>label.ab{ color: blue; }</style>');
     });
     it('rewrites a class= given lookups', function() {
-      var lookups = { 'class=email': 'ab' };
+      var lookups = { 'class': { 'email': 'ab' }};
       var html = '<style>form [class=email] { color: blue; }</style>';
       var $ = cheerio.load(html);
       var results = htmlUglify.rewriteStyles($, lookups).html();
       assert.equal(results, "<style>form [class=ab] { color: blue; }</style>");
     });
     it('rewrites multi-selector rule', function() {
-      var lookups = { 'class=email': 'ab' };
+      var lookups = { 'class': { 'email': 'ab' }};
       var html = '<style>label.email, a.email { color: blue; }</style>';
       var $ = cheerio.load(html);
       var results = htmlUglify.rewriteStyles($, lookups).html();
       assert.equal(results, '<style>label.ab, a.ab { color: blue; }</style>');
     });
     it('rewrites css media queries', function() {
-      var lookups = { 'id=abe': 'wz' };
+      var lookups = { 'id': { 'abe': 'wz' }};
 
       var html = '<style>@media screen and (max-width: 300px) { #abe{ color: red; } }</style>';
       var $ = cheerio.load(html);
@@ -164,7 +164,7 @@ describe('HTMLUglify', function() {
       assert.equal(results, '<style>@media screen and (max-width: 300px) { #wz{ color: red; } }</style>');
     });
     it('rewrites nested css media queries', function() {
-      var lookups = { 'id=abe': 'wz' };
+      var lookups = { 'id': { 'abe': 'wz' }};
 
       var html = '<style>@media { @media screen and (max-width: 300px) { #abe{ color: red; } } }</style>';
       var $ = cheerio.load(html);
@@ -244,8 +244,8 @@ describe('HTMLUglify', function() {
 
   describe('#process', function() {
     it('uglifies style and html', function() {
-      var html = htmlUglify.process("<style>.demo_class#andID{color: red}</style><div class='demo_class' id='andID'>Welcome to HTML Uglify</div>");
-      assert.equal(html, '<style>.xz#wk{color: red}</style><div class="xz" id="wk">Welcome to HTML Uglify</div>');
+      var html = htmlUglify.process("<style>.test#other{}</style><p class='test' id='other'></p>");
+      assert.equal(html, '<style>.xz#wk{}</style><p class="xz" id="wk"></p>');
     });
     it('uglifies differently with a different salt', function() {
       var htmlUglify = new HTMLUglify({salt: 'other'});
@@ -285,6 +285,10 @@ describe('HTMLUglify', function() {
     it('uglifies for attribute selectors', function() {
       var html = htmlUglify.process('<style>body[yahoo] *[id*=paddingreset] { padding:0 !important; }</style><div for="paddingreset1">paddingreset1</div>');
       assert.equal(html, '<style>body[yahoo] *[id*=xz] { padding:0 !important; }</style><div for="xz1">paddingreset1</div>');
+    });
+    it('uglifies similar class names but no attribute selectors in use', function() {
+      var html = htmlUglify.process("<style>.test{} .testOther{} .otratest{}</style><p class='test testOther otratest'></p>");
+      assert.equal(html, '<style>.xz{}</style><p class="xz"></p>')
     });
   });
 

--- a/test/main.js
+++ b/test/main.js
@@ -37,21 +37,21 @@ describe('HTMLUglify', function() {
     });
   });
   describe('#checkForCompoundPointer', function() {
-    it('returns undefined when name does not start with the same class', function() {
+    it('returns undefined when name does not contain the same class', function() {
       var lookups = {
         'class=something': 'zzz'
       };
-      var lookupKey = 'class=othersomething';
-      var pointer = htmlUglify.checkForCompoundPointer(lookups, lookupKey);
+      var value = 'other';
+      var pointer = htmlUglify.checkForCompoundPointer(lookups, value);
 
-      assert.isUndefined;
+      assert.isUndefined(pointer);
     });
     it('returns the pointer that starts with the same class', function() {
       var lookups = {
         'class=something': 'zzz'
       };
-      var lookupKey = 'somethingElse';
-      var pointer = htmlUglify.checkForCompoundPointer(lookups, lookupKey);
+      var value = 'somethingElse';
+      var pointer = htmlUglify.checkForCompoundPointer(lookups, value);
 
       assert.equal(pointer, 'zzzElse');
     });
@@ -294,10 +294,10 @@ describe('HTMLUglify', function() {
         var html = htmlUglify.process('<style>*[class=test] {}</style><div class="test"></div>');
         assert.equal(html, '<style>*[class=xz] {}</style><div class="xz"></div>');
 
-        var html = htmlUglify.process('<style>*[id=test] {}</style><div id="test"></div>');
+        html = htmlUglify.process('<style>*[id=test] {}</style><div id="test"></div>');
         assert.equal(html, '<style>*[id=xz] {}</style><div id="xz"></div>');
 
-        var html = htmlUglify.process('<style>*[id=test] {}</style><div for="test"></div>');
+        html = htmlUglify.process('<style>*[id=test] {}</style><div for="test"></div>');
         assert.equal(html, '<style>*[id=xz] {}</style><div for="xz"></div>');
       });
     });
@@ -306,10 +306,10 @@ describe('HTMLUglify', function() {
         var html = htmlUglify.process('<style>*[class*=test] {}</style><div class="ZZtestZZ"></div>');
         assert.equal(html, '<style>*[class*=xz] {}</style><div class="ZZxzZZ"></div>');
 
-        var html = htmlUglify.process('<style>*[id*=test] {}</style><div id="ZZtestZZ"></div>');
+        html = htmlUglify.process('<style>*[id*=test] {}</style><div id="ZZtestZZ"></div>');
         assert.equal(html, '<style>*[id*=xz] {}</style><div id="ZZxzZZ"></div>');
 
-        var html = htmlUglify.process('<style>*[id*=test] {}</style><div for="ZZtestZZ"></div>');
+        html = htmlUglify.process('<style>*[id*=test] {}</style><div for="ZZtestZZ"></div>');
         assert.equal(html, '<style>*[id*=xz] {}</style><div for="ZZxzZZ"></div>');
       });
 
@@ -317,10 +317,10 @@ describe('HTMLUglify', function() {
         var html = htmlUglify.process('<style>*[class*=test] {}</style><div class="testZZ"></div>');
         assert.equal(html, '<style>*[class*=xz] {}</style><div class="xzZZ"></div>');
 
-        var html = htmlUglify.process('<style>*[id*=test] {}</style><div id="testZZ"></div>');
+        html = htmlUglify.process('<style>*[id*=test] {}</style><div id="testZZ"></div>');
         assert.equal(html, '<style>*[id*=xz] {}</style><div id="xzZZ"></div>');
 
-        var html = htmlUglify.process('<style>*[id*=test] {}</style><div for="testZZ"></div>');
+        html = htmlUglify.process('<style>*[id*=test] {}</style><div for="testZZ"></div>');
         assert.equal(html, '<style>*[id*=xz] {}</style><div for="xzZZ"></div>');
       });
 
@@ -328,10 +328,10 @@ describe('HTMLUglify', function() {
         var html = htmlUglify.process('<style>*[class*=test] {}</style><div class="ZZtest"></div>');
         assert.equal(html, '<style>*[class*=xz] {}</style><div class="ZZxz"></div>');
 
-        var html = htmlUglify.process('<style>*[id*=test] {}</style><div id="ZZtest"></div>');
+        html = htmlUglify.process('<style>*[id*=test] {}</style><div id="ZZtest"></div>');
         assert.equal(html, '<style>*[id*=xz] {}</style><div id="ZZxz"></div>');
 
-        var html = htmlUglify.process('<style>*[id*=test] {}</style><div for="ZZtest"></div>');
+        html = htmlUglify.process('<style>*[id*=test] {}</style><div for="ZZtest"></div>');
         assert.equal(html, '<style>*[id*=xz] {}</style><div for="ZZxz"></div>');
       });
     });
@@ -340,10 +340,10 @@ describe('HTMLUglify', function() {
         var html = htmlUglify.process('<style>*[class^=test] {}</style><div class="testZZ"></div>');
         assert.equal(html, '<style>*[class^=xz] {}</style><div class="xzZZ"></div>');
 
-        var html = htmlUglify.process('<style>*[id^=test] {}</style><div id="testZZ"></div>');
+        html = htmlUglify.process('<style>*[id^=test] {}</style><div id="testZZ"></div>');
         assert.equal(html, '<style>*[id^=xz] {}</style><div id="xzZZ"></div>');
 
-        var html = htmlUglify.process('<style>*[id^=test] {}</style><div for="testZZ"></div>');
+        html = htmlUglify.process('<style>*[id^=test] {}</style><div for="testZZ"></div>');
         assert.equal(html, '<style>*[id^=xz] {}</style><div for="xzZZ"></div>');
       });
     });
@@ -352,10 +352,10 @@ describe('HTMLUglify', function() {
         var html = htmlUglify.process('<style>*[class$=test] {}</style><div class="ZZtest"></div>');
         assert.equal(html, '<style>*[class$=xz] {}</style><div class="ZZxz"></div>');
 
-        var html = htmlUglify.process('<style>*[id$=test] {}</style><div id="ZZtest"></div>');
+        html = htmlUglify.process('<style>*[id$=test] {}</style><div id="ZZtest"></div>');
         assert.equal(html, '<style>*[id$=xz] {}</style><div id="ZZxz"></div>');
 
-        var html = htmlUglify.process('<style>*[id$=test] {}</style><div for="ZZtest"></div>');
+        html = htmlUglify.process('<style>*[id$=test] {}</style><div for="ZZtest"></div>');
         assert.equal(html, '<style>*[id$=xz] {}</style><div for="ZZxz"></div>');
       });
     });


### PR DESCRIPTION
Gives you the ability to add `class*=` and `id*=` attribute sub selectors. Smartly uglifies.

For example, the following...

``` html
<style>
  body[yahoo] *[class*="start"] { padding:0 !important; }
</style>
<div class="startHere"></div>
<div class="startThere"></div>
```

... will be uglified to something like this:

``` html
<style>
  body[yahoo] *[class*="xz"] { padding:0 !important; }
</style>
<div class="xzHere"></div>
<div class="xzThere"></div>
```
